### PR TITLE
Proposed fix to shouldContainError() and overload to support deep property checks

### DIFF
--- a/src/commonMain/kotlin/io/kotest/assertions/konform/matchers.kt
+++ b/src/commonMain/kotlin/io/kotest/assertions/konform/matchers.kt
@@ -40,7 +40,15 @@ inline fun <T> Validation<T>.shouldBeInvalid(value: T, fn: (Invalid<T>) -> Unit)
 
 fun Invalid<*>.shouldContainError(field: Any, error: String) {
    val list = this[field]
-   list?.let {
+   list.let {
+      it.shouldNotBeNull()
+      it shouldContain error
+   }
+}
+
+fun Invalid<*>.shouldContainError(propertyPaths: Collection<Any>, error: String) {
+   val list = this.get(*propertyPaths.toTypedArray())
+   list.let {
       it.shouldNotBeNull()
       it shouldContain error
    }

--- a/src/jvmTest/kotlin/com/sksamuel/kotest/tests/konform/ValidatedMatchersTest.kt
+++ b/src/jvmTest/kotlin/com/sksamuel/kotest/tests/konform/ValidatedMatchersTest.kt
@@ -46,9 +46,64 @@ class ValidatedMatchersTest : StringSpec({
       }
    }
 
+   "shouldNotBeValidBook_MissedAssertion" {
+      val invalidUser = UserProfile("Alice", -1)
+
+      validateUser shouldBeInvalid invalidUser
+
+      validateUser.shouldBeInvalid(invalidUser) {
+         println(it)
+         it.shouldContainError(UserProfile::age, "must be at least '0'")
+         // original implementation of shouldContainError() fails to
+         // spot this and complain that this error is missing
+         shouldThrow<AssertionError> {
+            it.shouldContainError(UserProfile::fullName, "must have at least 2 characters")
+         }
+      }
+   }
+
+   val validateBook = Validation<Book> {
+      Book::title required {
+         maxLength(30)
+      }
+
+      Book::author required {
+         UserProfile::fullName {
+            minLength(2)
+            maxLength(100)
+         }
+
+         UserProfile::age ifPresent {
+            minimum(0)
+            maximum(150)
+         }
+      }
+   }
+
+   "shouldNotBeValidBook_DeepField" {
+      val invalidBook = Book(
+         title = "Wonderland",
+         author = UserProfile("", 25)
+      )
+
+      validateBook.shouldBeInvalid(invalidBook) {
+         println(it)
+         // the following assertion just doesn't work because of the propertyPath
+         // is too shallow:
+         // it.shouldContainError(UserProfile::fullName, "must have at least 2 characters")
+         // so I propose an overloaded implementation that takes a collection of propertyPaths:
+         it.shouldContainError(listOf(Book::author, UserProfile::fullName), "must have at least 2 characters")
+      }
+   }
+
 })
 
 private data class UserProfile(
    val fullName: String,
    val age: Int?
+)
+
+private data class Book(
+   val title: String,
+   val author: UserProfile,
 )


### PR DESCRIPTION
Sam, I have two contributions to kotest-assertions-konform

1) Missed Constraint violations
I have found that `shouldContainError()` does not quite work how I think you imagined it should work

   Using the original test class UserProfile, I created a new Unit Test which constructs a UserProfile with one error (age too low) but then add two Constraints that should be broken. The matcher doesn't spot the second Constraint doesn't get raised.

   The reason was a single `?` on the `let` see line 43 of matchers.kt

2) Deep constraint support
We sometimes are validating models with inner objects. `shouldContainError()` does not support these because the way it looks that it for the constraints it only looks at one level of` propertyPath`. My proposal suggests a way to handle deep constraint checks. 


I have left `println(it)` and comments to explain my work; please do remove these if you accept my contribution, and if you do I'll make a PR for updating the user docs:  https://github.com/kotest/kotest/blob/master/documentation/versioned_docs/version-5.5/assertions/konform.md